### PR TITLE
ARCH-1907 - Remove instances of set-output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,4 +19,4 @@ runs:
       id: step_1
       shell: bash
       run: |
-        echo "::set-output name=hello::world"
+        echo "hello=world" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Summary of PR changes
Updating workflows to comply with GitHub's request to deprecate the `set-output` & `save-state` command in workflows/actions.


## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
